### PR TITLE
Add dirwatch as an app dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
   {dirwatch,
-    {git, "http://github.com/tokenrove/erl-dirwatch.git", {tag, "v0.2"}}}
+    {git, "http://github.com/adgear/erl-dirwatch.git", {tag, "v0.2.1"}}}
  ]}.
 
 {erl_opts,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"dirwatch">>,
-  {git,"http://github.com/tokenrove/erl-dirwatch.git",
-       {ref,"1404ce78afef9690e3767c145318d225087051b2"}},
+  {git,"http://github.com/adgear/erl-dirwatch.git",
+       {ref,"3ba1fc19c1b1ae317e3c28934d9870640ed11349"}},
   0}].

--- a/src/bertconf.app.src
+++ b/src/bertconf.app.src
@@ -3,7 +3,7 @@
   {vsn, git},
   {modules, [bertconf, bertconf_sup, bertconf_lib, bertconf_bert_loader]},
   {registered, []},
-  {applications, [kernel, stdlib]},
+  {applications, [kernel, stdlib, dirwatch]},
   {mod, {bertconf, []}},
   {env, [
     {delay, 5000},
@@ -11,4 +11,3 @@
    ]}
  ]
 }.
-


### PR DESCRIPTION
If one tries to make a release with relx, the absence of dirwatch in
the applications tuple fails to bring the dirwatch repository in the
resulting tarball.